### PR TITLE
Rewrite the functionality of commander

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@
 
 ## What is commander
 
-Commander is a platform agnostic command framework for Minecraft server implementations. With Commander you can ideally write your commands once and use them everywhere. This is done through the Commander class which handles platform specific command registration. With Commander there are a variety of features: force command registration, annotation-based commands, command aliasing and child commands.
+Commander is a platform agnostic command framework for Minecraft server implementations.
+
+With Commander you can write commands and have permission resolving and child command resolving!
 
 ## Why
 
-This project was mainly written for the [DynamicGui](https://github.com/ClubObsidian/DynamicGui) which currently has a wrapper for Bukkit and Sponge support but the commands have to be written seperately. This project implements a number of wrapper classes for things such as: players, senders, worlds etc so that code can be written once and ran on many.
+This project was mainly written for [DynamicGui](https://github.com/ClubObsidian/DynamicGui) to simplify command registration.
 
 ## How do I use it
 

--- a/src/main/java/com/github/ravenlab/commander/command/CommanderCommand.java
+++ b/src/main/java/com/github/ravenlab/commander/command/CommanderCommand.java
@@ -9,7 +9,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import com.github.ravenlab.commander.command.parser.CommandDataParser;
-import com.github.ravenlab.commander.sender.CommanderSender;
 
 public abstract class CommanderCommand {
 	
@@ -25,7 +24,7 @@ public abstract class CommanderCommand {
 		this.childrenMap = new HashMap<>();
 	}
 	
-	public abstract void doCommand(CommanderSender<?> sender, String name, CommandArgs arg);
+	public abstract <T> void doCommand(T sender, String name, CommandArgs arg);
 	
 	public Optional<CommandData> getData() {
 		return this.data;

--- a/src/main/java/com/github/ravenlab/commander/command/CommanderExecutor.java
+++ b/src/main/java/com/github/ravenlab/commander/command/CommanderExecutor.java
@@ -26,10 +26,11 @@ public class CommanderExecutor {
 		
 		String[] executeArgs = parserData.getArgs();
 		String permission = commandData.getPermission();
+		Object nativeSender = sender.getNative();
 		
 		if(permission.equals("") || sender.hasPermission(permission)) {
 			CommandArgs commandArgs = new CommandArgs(Arrays.asList(executeArgs), this.resolver);
-			commandToExecute.doCommand(sender, label, commandArgs);
+			commandToExecute.doCommand(nativeSender, label, commandArgs);
 		} else {
 			String noPermissionMessage = commandData.getNoPermissionMessage();
 			sender.sendMessage(noPermissionMessage);

--- a/src/main/java/com/github/ravenlab/commander/resolver/TypeResolver.java
+++ b/src/main/java/com/github/ravenlab/commander/resolver/TypeResolver.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import com.github.ravenlab.commander.player.CommanderPlayer;
+import com.github.ravenlab.commander.sender.CommanderSender;
 import com.github.ravenlab.commander.world.CommanderWorld;
 
 public interface TypeResolver {
@@ -11,4 +12,5 @@ public interface TypeResolver {
 	public Optional<CommanderPlayer<?>> getPlayer(String name);
 	public Optional<CommanderPlayer<?>> getPlayer(UUID uuid);
 	public Optional<CommanderWorld<?>> getWorld(String name);
+	public CommanderSender<?> getSender(Object nativeSender);
 }

--- a/src/main/java/com/github/ravenlab/commander/resolver/bukkit/BukkitTypeResolver.java
+++ b/src/main/java/com/github/ravenlab/commander/resolver/bukkit/BukkitTypeResolver.java
@@ -5,11 +5,14 @@ import java.util.UUID;
 
 import org.bukkit.Bukkit;
 import org.bukkit.World;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 import com.github.ravenlab.commander.player.CommanderPlayer;
 import com.github.ravenlab.commander.player.bukkit.BukkitCommanderPlayer;
 import com.github.ravenlab.commander.resolver.TypeResolver;
+import com.github.ravenlab.commander.sender.CommanderSender;
+import com.github.ravenlab.commander.sender.bukkit.BukkitCommanderSender;
 import com.github.ravenlab.commander.world.CommanderWorld;
 import com.github.ravenlab.commander.world.bukkit.BukkitCommanderWorld;
 
@@ -47,5 +50,16 @@ public class BukkitTypeResolver implements TypeResolver {
 		
 		CommanderWorld<?> commanderWorld = new BukkitCommanderWorld(bukkitWorld);
 		return Optional.of(commanderWorld);
+	}
+
+	@Override
+	public CommanderSender<?> getSender(Object nativeSender) {
+		if(nativeSender instanceof Player) {
+			Player player = (Player) nativeSender;
+			return new BukkitCommanderPlayer(player);
+		} else {
+			CommandSender commandSender = (CommandSender) nativeSender;
+			return new BukkitCommanderSender(commandSender);
+		}
 	}
 }

--- a/src/test/java/com/github/commander/test/bukkit/BukkitTypeResolverTest.java
+++ b/src/test/java/com/github/commander/test/bukkit/BukkitTypeResolverTest.java
@@ -13,12 +13,14 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.github.commander.test.bukkit.mock.BukkitMockFactory;
+import com.github.commander.test.bukkit.mock.MockBukkitCommandSender;
 import com.github.commander.test.bukkit.mock.MockBukkitPlayer;
 import com.github.commander.test.bukkit.mock.MockBukkitServer;
 import com.github.commander.test.bukkit.mock.MockBukkitWorld;
 import com.github.ravenlab.commander.player.CommanderPlayer;
 import com.github.ravenlab.commander.resolver.TypeResolver;
 import com.github.ravenlab.commander.resolver.bukkit.BukkitTypeResolver;
+import com.github.ravenlab.commander.sender.CommanderSender;
 import com.github.ravenlab.commander.world.CommanderWorld;
 
 public class BukkitTypeResolverTest {
@@ -26,6 +28,7 @@ public class BukkitTypeResolverTest {
 	private MockBukkitServer server;
 	private MockBukkitPlayer player;
 	private MockBukkitWorld world;
+	private MockBukkitCommandSender sender;
 	
 	@Before
 	public void bootstrapServer() {
@@ -35,6 +38,7 @@ public class BukkitTypeResolverTest {
 		UUID uuid = UUID.randomUUID();
 		String playerName = "test";
 		this.player = factory.createPlayer(playerName, uuid);
+		this.sender = factory.createSender("test");
 		this.server.addPlayer(this.player);
 		this.world = factory.createWorld("test");
 		this.server.addWorld(this.world);
@@ -94,5 +98,19 @@ public class BukkitTypeResolverTest {
 		Optional<CommanderWorld<?>> worldOptional = resolver.getWorld(this.world.getName());
 		assertTrue(worldOptional.isPresent());
 		assertTrue(worldOptional.get().getName().equals(this.world.getName()));
+	}
+	
+	@Test
+	public void getSenderPlayerTest() {
+		TypeResolver resolver = new BukkitTypeResolver();
+		CommanderSender<?> sender = resolver.getSender(this.player);
+		assertTrue(sender.getName().equals(this.player.getName()));
+	}
+	
+	@Test
+	public void getSenderOtherTest() {
+		TypeResolver resolver = new BukkitTypeResolver();
+		CommanderSender<?> sender = resolver.getSender(this.sender);
+		assertTrue(sender.getName().equals(this.sender.getName()));
 	}
 }

--- a/src/test/java/com/github/commander/test/command/GrandChildCommand.java
+++ b/src/test/java/com/github/commander/test/command/GrandChildCommand.java
@@ -3,12 +3,11 @@ package com.github.commander.test.command;
 import com.github.ravenlab.commander.command.Command;
 import com.github.ravenlab.commander.command.CommandArgs;
 import com.github.ravenlab.commander.command.CommanderCommand;
-import com.github.ravenlab.commander.sender.CommanderSender;
 
 @Command("grandchild")
 public class GrandChildCommand extends CommanderCommand {
 
 	@Override
-	public void doCommand(CommanderSender<?> sender, String name, CommandArgs arg) {}
+	public <TestSender> void doCommand(TestSender sender, String name, CommandArgs arg) {}
 
 }

--- a/src/test/java/com/github/commander/test/command/NoAnnotationCommand.java
+++ b/src/test/java/com/github/commander/test/command/NoAnnotationCommand.java
@@ -2,11 +2,10 @@ package com.github.commander.test.command;
 
 import com.github.ravenlab.commander.command.CommandArgs;
 import com.github.ravenlab.commander.command.CommanderCommand;
-import com.github.ravenlab.commander.sender.CommanderSender;
 
 public class NoAnnotationCommand extends CommanderCommand {
 
 	@Override
-	public void doCommand(CommanderSender<?> sender, String name, CommandArgs arg) {}
+	public <TestSender> void doCommand(TestSender sender, String name, CommandArgs arg) {}
 
 }

--- a/src/test/java/com/github/commander/test/command/ParentCommand.java
+++ b/src/test/java/com/github/commander/test/command/ParentCommand.java
@@ -3,7 +3,6 @@ package com.github.commander.test.command;
 import com.github.ravenlab.commander.command.Command;
 import com.github.ravenlab.commander.command.CommandArgs;
 import com.github.ravenlab.commander.command.CommanderCommand;
-import com.github.ravenlab.commander.sender.CommanderSender;
 
 @Command(
 	value = "parent", 
@@ -19,7 +18,7 @@ public class ParentCommand extends CommanderCommand {
 	}
 	
 	@Override
-	public void doCommand(CommanderSender<?> sender, String name, CommandArgs arg) {
+	public <TestSender> void doCommand(TestSender sender, String name, CommandArgs arg) {
 		this.ran = true;
 	}
 	

--- a/src/test/java/com/github/commander/test/resolver/TestTypeResolver.java
+++ b/src/test/java/com/github/commander/test/resolver/TestTypeResolver.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 import com.github.ravenlab.commander.player.CommanderPlayer;
 import com.github.ravenlab.commander.resolver.TypeResolver;
+import com.github.ravenlab.commander.sender.CommanderSender;
 import com.github.ravenlab.commander.world.CommanderWorld;
 
 public class TestTypeResolver implements TypeResolver {
@@ -23,6 +24,12 @@ public class TestTypeResolver implements TypeResolver {
 
 	@Override
 	public Optional<CommanderWorld<?>> getWorld(String name) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public CommanderSender<?> getSender(Object nativeSender) {
 		// TODO Auto-generated method stub
 		return null;
 	}


### PR DESCRIPTION
Commander is no longer meant to be write once and run anywhere. While this would be nice it is essentially a pipe dream and would cause a lot of overhead. Instead commands in DynamicGui in the future will likely just have their own compability layer or use CommanderSenders, since that could still be used. This was done due to too much boilerplate having to be written and then maintaining the code between multiple version would be an issue for just myself to maintain.